### PR TITLE
Voter Macros

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -8,6 +8,9 @@ dependencies:
   common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.0 }
   register_interface:  { git: "https://github.com/pulp-platform/register_interface.git", version: 0.4.4 }
   common_cells:        { git: "https://github.com/pulp-platform/common_cells.git", version: 1.35.0 }
+  
+export_include_dirs:
+  - include
 
 sources:
     # Source files grouped in levels. Files in level 0 have no dependencies on files in this
@@ -23,6 +26,7 @@ sources:
   - rtl/hsiao_ecc/hsiao_ecc_dec.sv
   - rtl/hsiao_ecc/hsiao_ecc_cor.sv
   - rtl/TMR_voter.sv
+  - rtl/TMR_voter_fail.sv
   - rtl/TMR_word_voter.sv
     # Level 1
   - rtl/ODRG_unit/odrg_manager_reg_top.sv
@@ -68,6 +72,7 @@ sources:
   - rtl/TMR_voter_detect.sv
     # Level 2
   - rtl/bitwise_TMR_voter.sv
+  - rtl/bitwise_TMR_voter_fail.sv
   - rtl/ecc_wrap/ecc_manager.sv
   - target: deprecated
     files:
@@ -88,9 +93,12 @@ sources:
       - test/tb_ecc_secded.sv
       - test/tb_ecc_sram.sv
       - test/tb_tmr_voter.sv
+      - test/tb_tmr_voter_fail.sv
       - test/tb_tmr_voter_detect.sv
       - test/tb_tmr_word_voter.sv
       - test/tb_bitwise_tmr_voter.sv
+      - test/tb_bitwise_tmr_voter_fail.sv
+      - test/tb_voter_macros.sv
 
 vendor_package:
   - name: lowrisc_opentitan

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Available Flags are:
 - `F` Fault Detection: Additional 1-bit output signal which is one if voting was not unanimous
 - `W` Fault Location: Additional 3-bit output signal which specifies which input was different and 1-bit signal if all bits where different
 
-Voters work with enumerated types, but there is no guarante when multiple faults occurr at once that the output is a valid enum entry.
+Voters work with enumerated types, but there is no guarantee when multiple faults occur at once that the output is a valid enum entry.
 Enumerated types that consist of a single bit are not supported.
 
 All availabe voters are:

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Available Flags are:
 - `F` Fault Detection: Additional 1-bit output signal which is one if voting was not unanimous
 - `W` Fault Location: Additional 3-bit output signal which specifies which input was different and 1-bit signal if all bits where different
 
-Voters work with enumerated types, but there is no guarante when multiple faults occurr that the output is a valid enum entry.
-For Enum simulation in Questasim `vsim-3999` and `vopt-8386` errors need to be supressed.
+Voters work with enumerated types, but there is no guarante when multiple faults occurr at once that the output is a valid enum entry.
+Enumerated types that consist of a single bit are not supported.
 
 All availabe voters are:
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The `TMR_voter`s are Triple Modular Redundancy majority voters, based on researc
 ## Voting Macros
 For quickly instantiating voters, the following macros might be useful. They can be used via bender with:
 ```
-include "redundancy_cells/voters.svh"
+`include "redundancy_cells/voters.svh"
 ```
 All Macros use the following naming scheme:
 `VOTE{Inputs}{Outputs}{Flags}`

--- a/README.md
+++ b/README.md
@@ -61,11 +61,10 @@ include "redundancy_cells/voters.svh"
 All Macros use the following naming scheme:
 `VOTE{Inputs}{Outputs}{Flags}`
 
-For size `1` outputs can be arbitrarily sized arrays (denoted as size `K` below), 
-for size `3` inputs and outputs should be arrays of length 3 at the top level which at lower levels can again be arbitrarily (`K`) sized. 
-The size `X` allows for a parameter called `REP` to determine how many duplicates are used, 
-which allows to make designs which have parametric redundancy. 
-`REP` should be 1 (no redundancy), 2 (fault detection) or 3 (fault correction).
+- For size `1` outputs can be arbitrarily sized arrays (denoted as size `[K:0]` below), 
+- For size `3` inputs and outputs should be arrays of length 3 at the top level which at lower levels can again be arbitrarily (`K`) sized. 
+- The size `X` allows for a parameter to determine how many duplicates are used, which allows to make designs which have compile-time switchable redundancy. 
+The parameter should have a value of 1 (no redundancy), 2 (fault detection) or 3 (fault correction).
 
 Available Flags are:
 - `F` Fault Detection: Additional 1-bit output signal which is one if voting was not unanimous
@@ -84,10 +83,10 @@ All availabe voters are:
 | `VOTE33`   | `input_signal[2:0][K:0], output_signal[2:0][K:0]`                                 | 3 -> 3 Voters                                    |
 | `VOTE33F`  | `input_signal[2:0][K:0], output_signal[2:0][K:0], fault_any`                      | 3 -> 3 Voters with fault detection               |
 | `VOTE33W`  | `input_signal[2:0][K:0], output_signal[2:0][K:0], fault_210[2:0], fault_multiple` | 3 -> 3 Voters with fault location                |
-| `VOTEX1`   | `input_signal[REP:0][K:0], output_signal[K:0]`                                    | REP -> 1 Voter (REP is a parameter from 1 to 3)  |
-| `VOTEX1F`  | `input_signal[REP:0][K:0], output_signal[K:0], fault_any`                         | REP -> 1 Voter with fault detection              |
-| `VOTEXX`   | `input_signal[REP:0][K:0], output_signal[REP:0][K:0]`                             | REP -> REP Voters                                |
-| `VOTEXXF`  | `input_signal[REP:0][K:0], output_signal[REP:0][K:0], fault_any`                  | REP -> REP Voters with fault detection           |
+| `VOTEX1`   | `replicas, input_signal[REP:0][K:0], output_signal[K:0]`                          | replicas -> 1 Voter                              |
+| `VOTEX1F`  | `replicas, input_signal[REP:0][K:0], output_signal[K:0], fault_any`               | replicas -> 1 Voter with fault detection         |
+| `VOTEXX`   | `replicas, input_signal[REP:0][K:0], output_signal[REP:0][K:0]`                   | replicas -> replicas Voters                      |
+| `VOTEXXF`  | `replicas, input_signal[REP:0][K:0], output_signal[REP:0][K:0], fault_any`        | replicas -> replicas Voters with fault detection |
 
 ## Testing
 To run tests, execute the following command:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,42 @@ The `DropECC` parameter allows for a faster signal along the decode data path, n
 ## Triple Modular Redundancy majority voters
 The `TMR_voter`s are Triple Modular Redundancy majority voters, based on research indicated in the corresponding files. To detect the failing module, additional signals are implemented in higher-level modules.
 
+## Voting Macros
+For quickly instantiating voters, the following macros might be useful. They can be used via bender with:
+```
+include "redundancy_cells/voters.svh"
+```
+All Macros use the following naming scheme:
+`VOTE{Inputs}{Outputs}{Flags}`
+
+For size `1` outputs can be arbitrarily sized arrays (denoted as size `K` below), 
+for size `3` inputs and outputs should be arrays of length 3 at the top level which at lower levels can again be arbitrarily (`K`) sized. 
+The size `X` allows for a parameter called `REP` to determine how many duplicates are used, 
+which allows to make designs which have parametric redundancy. 
+`REP` should be 1 (no redundancy), 2 (fault detection) or 3 (fault correction).
+
+Available Flags are:
+- `F` Fault Detection: Additional 1-bit output signal which is one if voting was not unanimous
+- `W` Fault Location: Additional 3-bit output signal which specifies which input was different and 1-bit signal if all bits where different
+
+Voters work with enumerated types, but there is no guarante when multiple faults occurr that the output is a valid enum entry.
+For Enum simulation in Questasim `vsim-3999` and `vopt-8386` errors need to be supressed.
+
+All availabe voters are:
+
+| Macro      | Arguments                                                                         | Description                                      |
+|------------|-----------------------------------------------------------------------------------|--------------------------------------------------|
+| `VOTE31`   | `input_signal[2:0][K:0], output_signal[K:0]`                                      | 3 -> 1 Voter                                     |
+| `VOTE31F`  | `input_signal[2:0][K:0], output_signal[K:0], fault_any`                           | 3 -> 1 Voter with fault detection                |
+| `VOTE31W`  | `input_signal[2:0][K:0], output_signal[K:0], fault_210[2:0], fault_multiple`      | 3 -> 1 Voter with fault location                 |
+| `VOTE33`   | `input_signal[2:0][K:0], output_signal[2:0][K:0]`                                 | 3 -> 3 Voters                                    |
+| `VOTE33F`  | `input_signal[2:0][K:0], output_signal[2:0][K:0], fault_any`                      | 3 -> 3 Voters with fault detection               |
+| `VOTE33W`  | `input_signal[2:0][K:0], output_signal[2:0][K:0], fault_210[2:0], fault_multiple` | 3 -> 3 Voters with fault location                |
+| `VOTEX1`   | `input_signal[REP:0][K:0], output_signal[K:0]`                                    | REP -> 1 Voter (REP is a parameter from 1 to 3)  |
+| `VOTEX1F`  | `input_signal[REP:0][K:0], output_signal[K:0], fault_any`                         | REP -> 1 Voter with fault detection              |
+| `VOTEXX`   | `input_signal[REP:0][K:0], output_signal[REP:0][K:0]`                             | REP -> REP Voters                                |
+| `VOTEXXF`  | `input_signal[REP:0][K:0], output_signal[REP:0][K:0], fault_any`                  | REP -> REP Voters with fault detection           |
+
 ## Testing
 To run tests, execute the following command:
 ```bash

--- a/include/redundancy_cells/voters.svh
+++ b/include/redundancy_cells/voters.svh
@@ -1,0 +1,104 @@
+// Macros to instantiate some kind of Voters
+// If you want to use different kinds of Cells, you only have to change these
+`define TMR_INSTANCE(input_signal, output_signal, instance_name) \
+bitwise_TMR_voter_fail #(.DataWidth($bits(input_signal[0])), .VoterType(2)) instance_name ( \
+  .a_i(input_signal[0]), \
+  .b_i(input_signal[1]), \
+  .c_i(input_signal[2]), \
+  .majority_o(output_signal), \
+  .fault_detected_o() \
+);
+
+`define TMR_INSTANCE_F(input_signal, output_signal, fault_any, instance_name) \
+bitwise_TMR_voter_fail #(.DataWidth($bits(input_signal[0])), .VoterType(1)) instance_name ( \
+  .a_i(input_signal[0]), \
+  .b_i(input_signal[1]), \
+  .c_i(input_signal[2]), \
+  .majority_o(output_signal), \
+  .fault_detected_o(fault_any) \
+);
+
+`define TMR_INSTANCE_W(input_signal, output_signal, fault_210, fault_multiple, instance_name) \
+bitwise_TMR_voter #(.DataWidth($bits(input_signal[0])), .VoterType(2)) instance_name ( \
+  .a_i(input_signal[0]), \
+  .b_i(input_signal[1]), \
+  .c_i(input_signal[2]), \
+  .majority_o(output_signal), \
+  .error_o(fault_multiple), \
+  .error_cba_o(fault_210) \
+);
+
+// Macro to create a name based on the current line in the file
+// Name looks like: base_name_L42
+`define UNIQUE_NAME(base_name) ``base_name``_L```__LINE__
+
+// 3 -> 1 Voters
+`define VOTE31(input_signal, output_signal) \
+`TMR_INSTANCE(input_signal, output_signal, `UNIQUE_NAME(i_bitwise_TMR_voter_fail));
+
+`define VOTE31F(input_signal, output_signal, fault_any) \
+`TMR_INSTANCE_F(input_signal, output_signal, fault_any, `UNIQUE_NAME(i_bitwise_TMR_voter_fail));
+
+`define VOTE31W(input_signal, output_signal, fault_210, fault_multiple) \
+`TMR_INSTANCE_W(input_signal, output_signal, fault_210, fault_multiple, `UNIQUE_NAME(i_bitwise_TMR_voter));
+
+
+// 3 -> 3 Voters
+`define VOTE33(input_signal, output_signal) \
+`TMR_INSTANCE(input_signal, output_signal[0], `UNIQUE_NAME(i_bitwise_TMR_voter_fail_0)); \
+`TMR_INSTANCE(input_signal, output_signal[1], `UNIQUE_NAME(i_bitwise_TMR_voter_fail_1)); \
+`TMR_INSTANCE(input_signal, output_signal[2], `UNIQUE_NAME(i_bitwise_TMR_voter_fail_2));
+
+`define VOTE33F(input_signal, output_signal, fault_any) \
+`TMR_INSTANCE_F(input_signal, output_signal[0], fault_any, `UNIQUE_NAME(i_bitwise_TMR_voter_fail_0f)); \
+`TMR_INSTANCE(input_signal, output_signal[1], `UNIQUE_NAME(i_bitwise_TMR_voter_fail_1)); \
+`TMR_INSTANCE(input_signal, output_signal[2], `UNIQUE_NAME(i_bitwise_TMR_voter_fail_2));
+
+`define VOTE33W(input_signal, output_signal, fault_210, fault_multiple) \
+`TMR_INSTANCE_W(input_signal, output_signal[0], fault_210, fault_multiple, `UNIQUE_NAME(i_bitwise_TMR_voter_fail_0w)); \
+`TMR_INSTANCE(input_signal, output_signal[1], `UNIQUE_NAME(i_bitwise_TMR_voter_fail_1)); \
+`TMR_INSTANCE(input_signal, output_signal[2], `UNIQUE_NAME(i_bitwise_TMR_voter_fail_2));
+
+
+// localparam REP -> 1 Voters 
+`define VOTEX1(input_signal, output_signal) \
+if (REP == 3) begin \
+    `VOTE31(input_signal, output_signal); \
+end else if (REP == 2) begin \
+    assign output_signal = input_signal[0]; \
+end else begin \
+    assign output_signal = input_signal[0]; \
+end
+
+`define VOTEX1F(input_signal, output_signal, fault_any) \
+if (REP == 3) begin \
+    `VOTE31F(input_signal, output_signal, fault_any); \
+end else if (REP == 2) begin \
+    assign output_signal = input_signal[0]; \
+    assign fault_any = input_signal[0] != input_signal[1]; \
+end else begin \
+    assign output_signal = input_signal[0]; \
+    assign fault_any = 1'b1; \
+end
+
+
+// localparam REP -> REP Voters 
+`define VOTEXX(input_signal, output_signal) \
+if (REP == 3) begin \
+    `VOTE33(input_signal, output_signal); \
+end else if (REP == 2) begin \
+    assign output_signal = input_signal; \
+end else begin \
+    assign output_signal = input_signal; \
+end
+
+`define VOTEXXF(input_signal, output_signal, fault_any) \
+if (REP == 3) begin \
+    `VOTE33F(input_signal, output_signal, fault_any); \
+end else if (REP == 2) begin \
+    assign output_signal = input_signal; \
+    assign fault_any = input_signal[0] != input_signal[1]; \
+end else begin \
+    assign output_signal = input_signal; \
+    assign fault_any = 1'b1; \
+end

--- a/include/redundancy_cells/voters.svh
+++ b/include/redundancy_cells/voters.svh
@@ -132,7 +132,7 @@ end else if (replicas == 2) begin \
     assign fault_any = input_signal[0] != input_signal[1]; \
 end else if (replicas == 1) begin \
     assign output_signal = input_signal[0]; \
-    assign fault_any = 1'b1; \
+    assign fault_any = 1'b0; \
 end else begin \
     $fatal(1, "Unsupported number of replicas in voter macro!\n"); \
 end
@@ -143,9 +143,10 @@ end
 if (replicas == 3) begin \
     `VOTE33(input_signal, output_signal); \
 end else if (replicas == 2) begin \
-    assign output_signal = input_signal; \
+    assign output_signal[0] = input_signal[0]; \
+    assign output_signal[1] = input_signal[1]; \
 end else if (replicas == 1) begin \
-    assign output_signal = input_signal; \
+    assign output_signal[0] = input_signal[0]; \
 end else begin \
     $fatal(1, "Unsupported number of replicas in voter macro!\n"); \
 end
@@ -154,11 +155,12 @@ end
 if (replicas == 3) begin \
     `VOTE33F(input_signal, output_signal, fault_any); \
 end else if (replicas == 2) begin \
-    assign output_signal = input_signal; \
+    assign output_signal[0] = input_signal[0]; \
+    assign output_signal[1] = input_signal[1]; \
     assign fault_any = input_signal[0] != input_signal[1]; \
 end else if (replicas == 1) begin \
-    assign output_signal = input_signal; \
-    assign fault_any = 1'b1; \
+    assign output_signal[0] = input_signal[0]; \
+    assign fault_any = 1'b0; \
 end else begin \
     $fatal(1, "Unsupported number of replicas in voter macro!\n"); \
 end

--- a/include/redundancy_cells/voters.svh
+++ b/include/redundancy_cells/voters.svh
@@ -1,3 +1,15 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Macros to instantiate voters in a signel line
+
 // Macros to instantiate some kind of Voters
 // If you want to use different kinds of Cells, you only have to change these
 `define TMR_INSTANCE(input_signal, output_signal, instance_name) \
@@ -60,45 +72,53 @@ bitwise_TMR_voter #(.DataWidth($bits(input_signal[0])), .VoterType(2)) instance_
 `TMR_INSTANCE(input_signal, output_signal[2], `UNIQUE_NAME(i_bitwise_TMR_voter_fail_2));
 
 
-// localparam REP -> 1 Voters 
-`define VOTEX1(input_signal, output_signal) \
-if (REP == 3) begin \
+// localparam replicas -> 1 Voters 
+`define VOTEX1(replicas, input_signal, output_signal) \
+if (replicas == 3) begin \
     `VOTE31(input_signal, output_signal); \
-end else if (REP == 2) begin \
+end else if (replicas == 2) begin \
+    assign output_signal = input_signal[0]; \
+end else if (replicas == 1) begin \
     assign output_signal = input_signal[0]; \
 end else begin \
-    assign output_signal = input_signal[0]; \
+    $fatal(1, "Unsupported number of replicas in voter macro!\n"); \
 end
 
-`define VOTEX1F(input_signal, output_signal, fault_any) \
+`define VOTEX1F(replicas, input_signal, output_signal, fault_any) \
 if (REP == 3) begin \
     `VOTE31F(input_signal, output_signal, fault_any); \
-end else if (REP == 2) begin \
+end else if (replicas == 2) begin \
     assign output_signal = input_signal[0]; \
     assign fault_any = input_signal[0] != input_signal[1]; \
-end else begin \
+end else if (replicas == 1) begin \
     assign output_signal = input_signal[0]; \
     assign fault_any = 1'b1; \
+end else begin \
+    $fatal(1, "Unsupported number of replicas in voter macro!\n"); \
 end
 
 
-// localparam REP -> REP Voters 
-`define VOTEXX(input_signal, output_signal) \
+// localparam replicas -> replicas Voters 
+`define VOTEXX(replicas, input_signal, output_signal) \
 if (REP == 3) begin \
     `VOTE33(input_signal, output_signal); \
-end else if (REP == 2) begin \
+end else if (replicas == 2) begin \
+    assign output_signal = input_signal; \
+end else if (replicas == 1) begin \
     assign output_signal = input_signal; \
 end else begin \
-    assign output_signal = input_signal; \
+    $fatal(1, "Unsupported number of replicas in voter macro!\n"); \
 end
 
-`define VOTEXXF(input_signal, output_signal, fault_any) \
+`define VOTEXXF(replicas, input_signal, output_signal, fault_any) \
 if (REP == 3) begin \
     `VOTE33F(input_signal, output_signal, fault_any); \
-end else if (REP == 2) begin \
+end else if (replicas == 2) begin \
     assign output_signal = input_signal; \
     assign fault_any = input_signal[0] != input_signal[1]; \
-end else begin \
+end else if (replicas == 1) begin \
     assign output_signal = input_signal; \
     assign fault_any = 1'b1; \
+end else begin \
+    $fatal(1, "Unsupported number of replicas in voter macro!\n"); \
 end

--- a/include/redundancy_cells/voters.svh
+++ b/include/redundancy_cells/voters.svh
@@ -10,39 +10,79 @@
 //
 // Macros to instantiate voters in a signel line
 
-// Macros to instantiate some kind of Voters
-// If you want to use different kinds of Cells, you only have to change these
+
+// Helper Macro to use enums bitwise
+// This has no effect on array of bits, but does not work on plain logic!
+`define BITWISE(a) \
+  a[$bits(a)-1:0]
+
+
+// Cell Instantiation Macros
+// If you want to use different kinds of cells, you only have to change these
 `define TMR_INSTANCE(input_signal, output_signal, instance_name) \
-bitwise_TMR_voter_fail #(.DataWidth($bits(input_signal[0])), .VoterType(2)) instance_name ( \
-  .a_i(input_signal[0]), \
-  .b_i(input_signal[1]), \
-  .c_i(input_signal[2]), \
-  .majority_o(output_signal), \
-  .fault_detected_o() \
-);
+if ($bits(input_signal[0]) > 1) begin \
+    bitwise_TMR_voter_fail #(.DataWidth($bits(input_signal[0])), .VoterType(2)) instance_name ( \
+      .a_i(`BITWISE(input_signal[0])), \
+      .b_i(`BITWISE(input_signal[1])), \
+      .c_i(`BITWISE(input_signal[2])), \
+      .majority_o(`BITWISE(output_signal)), \
+      .fault_detected_o() \
+    ); \
+end else begin \
+    TMR_voter_fail #(.VoterType(2)) instance_name ( \
+      .a_i(input_signal[0]), \
+      .b_i(input_signal[1]), \
+      .c_i(input_signal[2]), \
+      .majority_o(output_signal), \
+      .fault_detected_o() \
+    ); \
+end
 
 `define TMR_INSTANCE_F(input_signal, output_signal, fault_any, instance_name) \
-bitwise_TMR_voter_fail #(.DataWidth($bits(input_signal[0])), .VoterType(1)) instance_name ( \
-  .a_i(input_signal[0]), \
-  .b_i(input_signal[1]), \
-  .c_i(input_signal[2]), \
-  .majority_o(output_signal), \
-  .fault_detected_o(fault_any) \
-);
+if ($bits(input_signal[0]) > 1) begin \
+    bitwise_TMR_voter_fail #(.DataWidth($bits(input_signal[0])), .VoterType(1)) instance_name ( \
+      .a_i(`BITWISE(input_signal[0])), \
+      .b_i(`BITWISE(input_signal[1])), \
+      .c_i(`BITWISE(input_signal[2])), \
+      .majority_o(`BITWISE(output_signal)), \
+      .fault_detected_o(fault_any) \
+    ); \
+end else begin \
+    TMR_voter_fail #(.VoterType(1)) instance_name ( \
+      .a_i(input_signal[0]), \
+      .b_i(input_signal[1]), \
+      .c_i(input_signal[2]), \
+      .majority_o(output_signal), \
+      .fault_detected_o(fault_any) \
+    ); \
+end
 
 `define TMR_INSTANCE_W(input_signal, output_signal, fault_210, fault_multiple, instance_name) \
-bitwise_TMR_voter #(.DataWidth($bits(input_signal[0])), .VoterType(2)) instance_name ( \
-  .a_i(input_signal[0]), \
-  .b_i(input_signal[1]), \
-  .c_i(input_signal[2]), \
-  .majority_o(output_signal), \
-  .error_o(fault_multiple), \
-  .error_cba_o(fault_210) \
-);
+if ($bits(input_signal[0]) > 1) begin \
+    bitwise_TMR_voter #(.DataWidth($bits(input_signal[0])), .VoterType(2)) instance_name ( \
+      .a_i(`BITWISE(input_signal[0])), \
+      .b_i(`BITWISE(input_signal[1])), \
+      .c_i(`BITWISE(input_signal[2])), \
+      .majority_o(`BITWISE(output_signal)), \
+      .error_o(fault_multiple), \
+      .error_cba_o(fault_210) \
+    ); \
+end else begin \
+    bitwise_TMR_voter #(.DataWidth($bits(input_signal[0])), .VoterType(2)) instance_name ( \
+      .a_i(input_signal[0]), \
+      .b_i(input_signal[1]), \
+      .c_i(input_signal[2]), \
+      .majority_o(output_signal), \
+      .error_o(fault_multiple), \
+      .error_cba_o(fault_210) \
+    ); \
+end
+
 
 // Macro to create a name based on the current line in the file
 // Name looks like: base_name_L42
 `define UNIQUE_NAME(base_name) ``base_name``_L```__LINE__
+
 
 // 3 -> 1 Voters
 `define VOTE31(input_signal, output_signal) \

--- a/include/redundancy_cells/voters.svh
+++ b/include/redundancy_cells/voters.svh
@@ -125,7 +125,7 @@ end else begin \
 end
 
 `define VOTEX1F(replicas, input_signal, output_signal, fault_any) \
-if (REP == 3) begin \
+if (replicas == 3) begin \
     `VOTE31F(input_signal, output_signal, fault_any); \
 end else if (replicas == 2) begin \
     assign output_signal = input_signal[0]; \
@@ -140,7 +140,7 @@ end
 
 // localparam replicas -> replicas Voters 
 `define VOTEXX(replicas, input_signal, output_signal) \
-if (REP == 3) begin \
+if (replicas == 3) begin \
     `VOTE33(input_signal, output_signal); \
 end else if (replicas == 2) begin \
     assign output_signal = input_signal; \
@@ -151,7 +151,7 @@ end else begin \
 end
 
 `define VOTEXXF(replicas, input_signal, output_signal, fault_any) \
-if (REP == 3) begin \
+if (replicas == 3) begin \
     `VOTE33F(input_signal, output_signal, fault_any); \
 end else if (replicas == 2) begin \
     assign output_signal = input_signal; \

--- a/rtl/TMR_voter_fail.sv
+++ b/rtl/TMR_voter_fail.sv
@@ -1,4 +1,4 @@
-// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright 2024 ETH Zurich and University of Bologna.
 // Copyright and related rights are licensed under the Solderpad Hardware
 // License, Version 0.51 (the "License"); you may not use this file except in
 // compliance with the License.  You may obtain a copy of the License at

--- a/rtl/TMR_voter_fail.sv
+++ b/rtl/TMR_voter_fail.sv
@@ -1,0 +1,50 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Triple Modular Redundancy Majority Voter (MV) for a single bit with a failure output
+//
+// Classical_MV: standard and & or gates
+// KP_MV:        Kshirsagar and Patrikar MV [https://doi.org/10.1016/j.microrel.2009.08.001]
+// BN_MV:        Ban and Naviner MV         [https://doi.org/10.1109/NEWCAS.2010.5603933]
+//
+// Fault detection logic added on our own Ideas
+
+module TMR_voter_fail #(
+  parameter int unsigned VoterType = 1 // 0: Classical_MV, 1: KP_MV, 2: BN_MV
+) (
+  input  logic a_i,
+  input  logic b_i,
+  input  logic c_i,
+  output logic majority_o,
+  output logic fault_detected_o
+);
+
+  if (VoterType == 0) begin : gen_classical_mv
+    assign majority_o = (a_i & b_i) | (a_i & c_i) | (b_i & c_i);
+    assign fault_detected_o = (a_i ^ b_i) | (a_i ^ c_i); // 3 extra gates
+  end else if (VoterType == 1) begin : gen_kp_mv
+    logic n_1, n_2, p;
+    assign n_1 = a_i ^ b_i;
+    assign n_2 = b_i ^ c_i;
+    assign p = n_1 & ~n_2;
+    assign majority_o = p ? c_i : a_i;
+    assign fault_detected_o = n_1 | n_2; // 1 extra gate
+  end else if (VoterType == 2) begin : gen_bn_mv
+    logic n;
+    assign n = a_i ^ b_i;
+    assign majority_o = n ? c_i : b_i;
+    assign fault_detected_o = n | b_i ^ c_i; // 2 extra gates
+  end else begin : gen_unsupported
+`ifndef TARGET_SYNTHESIS
+    $fatal(1, "Please select a valid VoterType.\n");
+`endif
+  end
+
+endmodule

--- a/rtl/bitwise_TMR_voter_fail.sv
+++ b/rtl/bitwise_TMR_voter_fail.sv
@@ -1,0 +1,40 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Triple Modular Redundancy Majority Voter (MV) for a data word
+
+module bitwise_TMR_voter_fail #(
+  parameter int unsigned DataWidth = 32,
+  parameter int unsigned VoterType = 1 // 0: Classical_MV, 1: KP_MV, 2: BN_MV
+) (
+  input  logic [DataWidth-1:0] a_i,
+  input  logic [DataWidth-1:0] b_i,
+  input  logic [DataWidth-1:0] c_i,
+  output logic [DataWidth-1:0] majority_o,
+  output logic                 fault_detected_o // Indicates any type of mismatch
+);
+
+  logic [DataWidth-1:0] fault_detected;
+
+  for (genvar i = 0; i < DataWidth; i++) begin : gen_bit_voters
+    TMR_voter_fail #(
+      .VoterType ( VoterType )
+    ) i_voter_fail (
+      .a_i              ( a_i[i]            ),
+      .b_i              ( b_i[i]            ),
+      .c_i              ( c_i[i]            ),
+      .majority_o       ( majority_o[i]     ),
+      .fault_detected_o ( fault_detected[i] )
+    );
+  end
+
+  assign fault_detected_o = |fault_detected;
+
+endmodule

--- a/rtl/bitwise_TMR_voter_fail.sv
+++ b/rtl/bitwise_TMR_voter_fail.sv
@@ -1,4 +1,4 @@
-// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright 2024 ETH Zurich and University of Bologna.
 // Copyright and related rights are licensed under the Solderpad Hardware
 // License, Version 0.51 (the "License"); you may not use this file except in
 // compliance with the License.  You may obtain a copy of the License at

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -48,4 +48,4 @@ call_vsim -GDataWidth=16 tb_ecc_secded
 call_vsim -GDataWidth=32 tb_ecc_secded
 call_vsim -GDataWidth=64 tb_ecc_secded
 call_vsim tb_ecc_scrubber
-call_vsim tb_voter_macros -suppress vsim-3999 -suppress vopt-8386
+call_vsim tb_voter_macros

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -37,12 +37,15 @@ call_vsim() {
 }
 
 call_vsim tb_tmr_voter
+call_vsim tb_tmr_voter_fail
 call_vsim tb_tmr_voter_detect
 call_vsim tb_tmr_word_voter
 call_vsim tb_bitwise_tmr_voter
+call_vsim tb_bitwise_tmr_voter_fail
 call_vsim tb_ecc_sram -voptargs="+acc=nr"
 call_vsim -GDataWidth=8 tb_ecc_secded
 call_vsim -GDataWidth=16 tb_ecc_secded
 call_vsim -GDataWidth=32 tb_ecc_secded
 call_vsim -GDataWidth=64 tb_ecc_secded
 call_vsim tb_ecc_scrubber
+call_vsim tb_voter_macros -suppress vsim-3999 -suppress vopt-8386

--- a/src_files.yml
+++ b/src_files.yml
@@ -10,8 +10,10 @@ redundancy_cells:
     lowrisc_ecc/prim_secded_72_64_dec.sv,
     lowrisc_ecc/prim_secded_72_64_enc.sv,
     rtl/TMR_voter.sv,
+    rtl/TMR_voter_fail.sv,
     rtl/TMR_word_voter,
     # Level 1
+    rtl/bitwise_TMR_voter_fail.sv
     rtl/ecc_concat_32_64.sv,
     rtl/ecc_sram_wrap.sv,
     rtl/BUS_enc_dec/AXI_bus_ecc_dec.sv,

--- a/test/tb_bitwise_tmr_voter_fail.sv
+++ b/test/tb_bitwise_tmr_voter_fail.sv
@@ -1,0 +1,279 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Testbench for bitwise TMR Word Voter with Failure Output
+
+module tb_bitwise_tmr_voter_fail;
+
+  localparam int unsigned RunCycles = 100000;
+  localparam int unsigned DataWidth = 32;
+
+  /******************
+   *  Helper tasks  *
+   ******************/
+
+  localparam time TTest  = 8ns;
+  localparam time TApply = 2ns;
+
+  task cycle_start();
+    #TApply;
+  endtask: cycle_start
+
+  task cycle_end();
+    #TTest;
+  endtask: cycle_end
+
+  /**********************
+   *  Helper variables  *
+   **********************/
+
+  longint test_cnt;
+
+  /************************
+   *  Stimuli generation  *
+   ************************/
+
+  // Data type
+  typedef logic [DataWidth-1:0] data_t;
+
+  class stimuli_t;
+    rand data_t a_i;
+    rand data_t b_i;
+    rand data_t c_i;
+
+    constraint equal_inputs { a_i == b_i; a_i == c_i; }
+    constraint a_i_different { a_i != b_i; b_i == c_i; }
+    constraint b_i_different { b_i != a_i; a_i == c_i; }
+    constraint c_i_different { c_i != a_i; a_i == b_i; }
+    constraint all_different { a_i != b_i; a_i != c_i; b_i != c_i; }
+  endclass: stimuli_t
+
+  // Stimuli
+  stimuli_t stimuli_queue [$];
+
+  // Golden values
+  typedef struct packed {
+    data_t majority_o;
+    logic fault_detected_o;
+  } result_t;
+
+  result_t golden_queue[$];
+
+  function automatic void generate_stimuli();
+    // Step 1: Three equal values
+    repeat (1)
+      for (int i = 0; i < RunCycles; i++) begin
+        automatic stimuli_t stimuli = new;
+
+        // Activate constraints
+        stimuli.equal_inputs.constraint_mode(1);
+        stimuli.a_i_different.constraint_mode(0);
+        stimuli.b_i_different.constraint_mode(0);
+        stimuli.c_i_different.constraint_mode(0);
+        stimuli.all_different.constraint_mode(0);
+
+        // Randomize
+        if (stimuli.randomize()) begin
+          stimuli_queue.push_back(stimuli);
+          golden_queue.push_back('{majority_o: stimuli.a_i, fault_detected_o: 1'b0});
+        end else
+          $error("Could not randomize.");
+      end
+
+    // Step 2: a_i is different
+    repeat (1)
+      for (int i = 0; i < RunCycles; i++) begin
+        automatic stimuli_t stimuli = new;
+
+        // Activate constraints
+        stimuli.equal_inputs.constraint_mode(0);
+        stimuli.a_i_different.constraint_mode(1);
+        stimuli.b_i_different.constraint_mode(0);
+        stimuli.c_i_different.constraint_mode(0);
+        stimuli.all_different.constraint_mode(0);
+
+        // Randomize
+        if (stimuli.randomize()) begin
+          stimuli_queue.push_back(stimuli);
+          golden_queue.push_back('{majority_o: stimuli.b_i, fault_detected_o: 1'b1});
+        end else
+          $error("Could not randomize.");
+      end
+
+    // Step 3: b_i is different
+    repeat (1)
+      for (int i = 0; i < RunCycles; i++) begin
+        automatic stimuli_t stimuli = new;
+
+        // Activate constraints
+        stimuli.equal_inputs.constraint_mode(0);
+        stimuli.a_i_different.constraint_mode(0);
+        stimuli.b_i_different.constraint_mode(1);
+        stimuli.c_i_different.constraint_mode(0);
+        stimuli.all_different.constraint_mode(0);
+
+        // Randomize
+        if (stimuli.randomize()) begin
+          stimuli_queue.push_back(stimuli);
+          golden_queue.push_back('{majority_o: stimuli.a_i, fault_detected_o: 1'b1});
+        end else
+          $error("Could not randomize.");
+      end
+
+    // Step 4: c_i is different
+    repeat (1)
+      for (int i = 0; i < RunCycles; i++) begin
+        automatic stimuli_t stimuli = new;
+
+        // Activate constraints
+        stimuli.equal_inputs.constraint_mode(0);
+        stimuli.a_i_different.constraint_mode(0);
+        stimuli.b_i_different.constraint_mode(0);
+        stimuli.c_i_different.constraint_mode(1);
+        stimuli.all_different.constraint_mode(0);
+
+        // Randomize
+        if (stimuli.randomize()) begin
+          stimuli_queue.push_back(stimuli);
+          golden_queue.push_back('{majority_o: stimuli.a_i, fault_detected_o: 1'b1});
+        end else
+          $error("Could not randomize.");
+      end
+
+    // Step 5: all different
+    repeat (1)
+      for (int i = 0; i < RunCycles; i++) begin
+        automatic stimuli_t stimuli = new;
+
+        // Activate constraints
+        stimuli.equal_inputs.constraint_mode(0);
+        stimuli.a_i_different.constraint_mode(0);
+        stimuli.b_i_different.constraint_mode(0);
+        stimuli.c_i_different.constraint_mode(0);
+        stimuli.all_different.constraint_mode(1);
+
+        // Randomize
+        if (stimuli.randomize()) begin
+          stimuli_queue.push_back(stimuli);
+          golden_queue.push_back('{majority_o: {DataWidth{1'b?}}, fault_detected_o: 1'b1});
+        end else
+          $error("Could not randomize.");
+      end
+  endfunction: generate_stimuli
+
+  // Apply stimuli
+  data_t a_i;
+  data_t b_i;
+  data_t c_i;
+
+  task automatic apply_stimuli();
+    automatic stimuli_t stimuli;
+
+    wait (stimuli_queue.size() != '0);
+
+    stimuli = stimuli_queue.pop_front();
+    a_i    = stimuli.a_i;
+    b_i    = stimuli.b_i;
+    c_i    = stimuli.c_i;
+  endtask: apply_stimuli
+
+  initial begin: init_stimuli
+    a_i = '0;
+    b_i = '0;
+    c_i = '0;
+  end: init_stimuli
+
+  /***********************
+   *  Device Under Test  *
+   ***********************/
+
+  data_t       majority_o;
+  logic        fault_detected_o;
+
+  bitwise_TMR_voter_fail #(
+    .DataWidth(DataWidth),
+    .VoterType(2        )
+  ) i_dut (
+    .a_i              ( a_i              ),
+    .b_i              ( b_i              ),
+    .c_i              ( c_i              ),
+    .majority_o       ( majority_o       ),
+    .fault_detected_o ( fault_detected_o )
+  );
+
+  /***********************
+   *  Output collection  *
+   ***********************/
+
+  result_t result_queue [$];
+
+  longint error_cnt;
+
+  function automatic void collect_result;
+    result_queue.push_back('{majority_o: majority_o, fault_detected_o: fault_detected_o});
+  endfunction: collect_result
+
+  task automatic check_result;
+    automatic result_t result;
+    automatic result_t golden;
+
+    do begin
+      wait(result_queue.size() != 0);
+
+      // Capture the results
+      result = result_queue.pop_front();
+      golden = golden_queue.pop_front();
+
+      // Account for this check
+      test_cnt++;
+
+      if (result != golden) begin
+        $warning("ERROR! Test %0d: expected %p, found %p.", test_cnt, golden, result);
+        error_cnt++;
+      end
+    end while (stimuli_queue.size() != 0);
+  endtask: check_result
+
+  /****************
+   *  Test bench  *
+   ****************/
+
+  task run();
+    // Apply stimuli and collect results cycle
+    forever begin
+      cycle_start();
+      apply_stimuli();
+      cycle_end();
+      collect_result();
+    end
+  endtask : run
+
+  initial begin: tb
+    // Initialize variables
+    test_cnt  = '0;
+    error_cnt = '0;
+
+    fork
+      // Run the TB
+      run();
+      fork
+        // Generate stimuli
+        generate_stimuli();
+        // Check result
+        check_result();
+      join
+    join_any
+
+    $display("Checked %0d tests, found %0d mismatches.", test_cnt, error_cnt);
+    $finish(error_cnt);
+  end: tb
+
+endmodule
+

--- a/test/tb_tmr_voter_fail.sv
+++ b/test/tb_tmr_voter_fail.sv
@@ -1,0 +1,147 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+// 
+// Testbench for TMR Voter with fault output
+
+module tb_tmr_voter_fail;
+
+  /******************
+   *  Helper tasks  *
+   ******************/
+
+  localparam time TTest  = 8ns;
+  localparam time TApply = 2ns;
+
+  task cycle_start();
+    #TApply;
+  endtask: cycle_start
+
+  task cycle_end();
+    #TTest;
+  endtask: cycle_end
+
+  /**********************
+   *  Helper variables  *
+   **********************/
+
+  longint test_cnt;
+
+  logic [2:0] in;
+  logic       out_classic, out_kp, out_bn;
+  logic       fault_classic, fault_kp, fault_bn;
+
+  TMR_voter_fail #(
+    .VoterType(0)
+  ) i_dut_classic (
+    .a_i              ( in[0]         ),
+    .b_i              ( in[1]         ),
+    .c_i              ( in[2]         ),
+    .majority_o       ( out_classic   ),
+    .fault_detected_o ( fault_classic )
+  );
+
+  TMR_voter_fail #(
+    .VoterType(1)
+  ) i_dut_kp (
+    .a_i              ( in[0]    ),
+    .b_i              ( in[1]    ),
+    .c_i              ( in[2]    ),
+    .majority_o       ( out_kp   ),
+    .fault_detected_o ( fault_kp )
+  );
+
+  TMR_voter_fail #(
+    .VoterType(2)
+  ) i_dut_bn (
+    .a_i              ( in[0]    ),
+    .b_i              ( in[1]    ),
+    .c_i              ( in[2]    ),
+    .majority_o       ( out_bn   ),
+    .fault_detected_o ( fault_bn )
+  );
+
+  initial begin
+    cycle_start();
+    in = 3'b000;
+    cycle_end();
+    assert(out_classic   == 1'b0);
+    assert(out_kp        == 1'b0);
+    assert(out_bn        == 1'b0);
+    assert(fault_classic == 1'b0);
+    assert(fault_kp      == 1'b0);
+    assert(fault_bn      == 1'b0);
+    cycle_start();
+    in = 3'b001;
+    cycle_end();
+    assert(out_classic   == 1'b0);
+    assert(out_kp        == 1'b0);
+    assert(out_bn        == 1'b0);
+    assert(fault_classic == 1'b1);
+    assert(fault_kp      == 1'b1);
+    assert(fault_bn      == 1'b1);
+    cycle_start();
+    in = 3'b010;
+    cycle_end();
+    assert(out_classic   == 1'b0);
+    assert(out_kp        == 1'b0);
+    assert(out_bn        == 1'b0);
+    assert(fault_classic == 1'b1);
+    assert(fault_kp      == 1'b1);
+    assert(fault_bn      == 1'b1);
+    cycle_start();
+    in = 3'b100;
+    cycle_end();
+    assert(out_classic   == 1'b0);
+    assert(out_kp        == 1'b0);
+    assert(out_bn        == 1'b0);
+    assert(fault_classic == 1'b1);
+    assert(fault_kp      == 1'b1);
+    assert(fault_bn      == 1'b1);
+
+    cycle_start();
+    in = 3'b111;
+    cycle_end();
+    assert(out_classic   == 1'b1);
+    assert(out_kp        == 1'b1);
+    assert(out_bn        == 1'b1);
+    assert(fault_classic == 1'b0);
+    assert(fault_kp      == 1'b0);
+    assert(fault_bn      == 1'b0);
+    cycle_start();
+    in = 3'b110;
+    cycle_end();
+    assert(out_classic   == 1'b1);
+    assert(out_kp        == 1'b1);
+    assert(out_bn        == 1'b1);
+    assert(fault_classic == 1'b1);
+    assert(fault_kp      == 1'b1);
+    assert(fault_bn      == 1'b1);
+    cycle_start();
+    in = 3'b101;
+    cycle_end();
+    assert(out_classic   == 1'b1);
+    assert(out_kp        == 1'b1);
+    assert(out_bn        == 1'b1);
+    assert(fault_classic == 1'b1);
+    assert(fault_kp      == 1'b1);
+    assert(fault_bn      == 1'b1);
+    cycle_start();
+    in = 3'b011;
+    cycle_end();
+    assert(out_classic   == 1'b1);
+    assert(out_kp        == 1'b1);
+    assert(out_bn        == 1'b1);
+    assert(fault_classic == 1'b1);
+    assert(fault_kp      == 1'b1);
+    assert(fault_bn      == 1'b1);
+  end
+
+endmodule
+

--- a/test/tb_voter_macros.sv
+++ b/test/tb_voter_macros.sv
@@ -1,0 +1,421 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Testbench for TMR Voter
+
+`include "redundancy_cells/voters.svh"
+
+module tb_voter_macros;
+
+  /******************
+   *  Helper tasks  *
+   ******************/
+
+  localparam time TTest  = 8ns;
+  localparam time TApply = 2ns;
+
+  task cycle_start();
+    #TApply;
+  endtask: cycle_start
+
+  task cycle_end();
+    #TTest;
+  endtask: cycle_end
+
+  /**********************
+   *  Helper variables  *
+   **********************/
+
+  logic [2:0] in;
+
+  logic       out_31, out_31f, out_31w;
+  logic       fail_31f;
+  logic [2:0] where_31w;
+  logic       total_31w;
+
+  logic [2:0] out_33, out_33f, out_33w;
+  logic       fail_33f;
+  logic [2:0] where_33w;
+  logic       total_33w;
+
+  // The same thing but with enums to ensure macros run fine with those
+  typedef enum logic [1:0] {ZERO, ONE, TWO}  dummy_enum_t;
+
+  dummy_enum_t [2:0] enum_in;
+
+  dummy_enum_t       enum_out_31, enum_out_31f, enum_out_31w;
+  logic              enum_fail_31f;
+  logic [2:0]        enum_where_31w;
+  logic              enum_total_31w;
+
+  dummy_enum_t [2:0] enum_out_33, enum_out_33f, enum_out_33w;
+  logic              enum_fail_33f;
+  logic [2:0]        enum_where_33w;
+  logic              enum_total_33w;
+
+  /**********************
+   *  DUTs              *
+   **********************/
+
+  `VOTE31 (in, out_31);
+  `VOTE31F(in, out_31f, fail_31f);
+  `VOTE31W(in, out_31w, where_31w, total_31w);
+
+  `VOTE33 (in, out_33);
+  `VOTE33F(in, out_33f, fail_33f);
+  `VOTE33W(in, out_33w, where_33w, total_33w);
+
+  // The same thing but with enums to ensure macros run fine with those
+  `VOTE31 (enum_in, enum_out_31);
+  `VOTE31F(enum_in, enum_out_31f, enum_fail_31f);
+  `VOTE31W(enum_in, enum_out_31w, enum_where_31w, enum_total_31w);
+
+  `VOTE33 (enum_in, enum_out_33);
+  `VOTE33F(enum_in, enum_out_33f, enum_fail_33f);
+  `VOTE33W(enum_in, enum_out_33w, enum_where_33w, enum_total_33w);
+
+  initial begin
+    cycle_start();
+    in = 3'b000;
+    enum_in = {ZERO, ZERO, ZERO};
+
+    cycle_end();
+    assert(out_31         == 1'b0);
+    assert(out_31f        == 1'b0);
+    assert(out_31w        == 1'b0);
+
+    assert(enum_out_31    == ZERO);
+    assert(enum_out_31f   == ZERO);
+    assert(enum_out_31w   == ZERO);
+
+    assert(out_33   == 3'b000);
+    assert(out_33f  == 3'b000);
+    assert(out_33w  == 3'b000);
+
+    assert(enum_out_33   == {ZERO, ZERO, ZERO});
+    assert(enum_out_33f  == {ZERO, ZERO, ZERO});
+    assert(enum_out_33w  == {ZERO, ZERO, ZERO});
+
+    assert(fail_31f       == 1'b0);
+    assert(enum_fail_31f  == 1'b0);
+    assert(fail_33f       == 1'b0);
+    assert(enum_fail_33f  == 1'b0);
+
+    assert(where_31w      == 3'b000);
+    assert(enum_where_31w == 3'b000);
+    assert(where_33w      == 3'b000);
+    assert(enum_where_33w == 3'b000);
+
+    assert(total_31w      == 1'b0);
+    assert(enum_total_31w == 1'b0);
+    assert(total_33w      == 1'b0);
+    assert(enum_total_33w == 1'b0);
+
+    cycle_start();
+    in = 3'b001;
+    enum_in = {ZERO, ZERO, ONE};
+
+    cycle_end();
+    assert(out_31         == 1'b0);
+    assert(out_31f        == 1'b0);
+    assert(out_31w        == 1'b0);
+
+    assert(enum_out_31    == ZERO);
+    assert(enum_out_31f   == ZERO);
+    assert(enum_out_31w   == ZERO);
+
+    assert(out_33   == 3'b000);
+    assert(out_33f  == 3'b000);
+    assert(out_33w  == 3'b000);
+
+    assert(enum_out_33   == {ZERO, ZERO, ZERO});
+    assert(enum_out_33f  == {ZERO, ZERO, ZERO});
+    assert(enum_out_33w  == {ZERO, ZERO, ZERO});
+
+    assert(fail_31f       == 1'b1);
+    assert(enum_fail_31f  == 1'b1);
+    assert(fail_33f       == 1'b1);
+    assert(enum_fail_33f  == 1'b1);
+
+    assert(where_31w      == 3'b001);
+    assert(enum_where_31w == 3'b001);
+    assert(where_33w      == 3'b001);
+    assert(enum_where_33w == 3'b001);
+
+    assert(total_31w      == 1'b0);
+    assert(enum_total_31w == 1'b0);
+    assert(total_33w      == 1'b0);
+    assert(enum_total_33w == 1'b0);
+
+
+    cycle_start();
+    in = 3'b010;
+    enum_in = {ZERO, ONE, ZERO};
+
+    cycle_end();
+    assert(out_31         == 1'b0);
+    assert(out_31f        == 1'b0);
+    assert(out_31w        == 1'b0);
+
+    assert(enum_out_31    == ZERO);
+    assert(enum_out_31f   == ZERO);
+    assert(enum_out_31w   == ZERO);
+
+    assert(out_33   == 3'b000);
+    assert(out_33f  == 3'b000);
+    assert(out_33w  == 3'b000);
+
+    assert(enum_out_33   == {ZERO, ZERO, ZERO});
+    assert(enum_out_33f  == {ZERO, ZERO, ZERO});
+    assert(enum_out_33w  == {ZERO, ZERO, ZERO});
+
+    assert(fail_31f       == 1'b1);
+    assert(enum_fail_31f  == 1'b1);
+    assert(fail_33f       == 1'b1);
+    assert(enum_fail_33f  == 1'b1);
+
+    assert(where_31w      == 3'b010);
+    assert(enum_where_31w == 3'b010);
+    assert(where_33w      == 3'b010);
+    assert(enum_where_33w == 3'b010);
+
+    assert(total_31w      == 1'b0);
+    assert(enum_total_31w == 1'b0);
+    assert(total_33w      == 1'b0);
+    assert(enum_total_33w == 1'b0);
+
+    cycle_start();
+    in = 3'b100;
+    enum_in = {ONE, ZERO, ZERO};
+
+    cycle_end();
+    assert(out_31         == 1'b0);
+    assert(out_31f        == 1'b0);
+    assert(out_31w        == 1'b0);
+
+    assert(enum_out_31    == ZERO);
+    assert(enum_out_31f   == ZERO);
+    assert(enum_out_31w   == ZERO);
+
+    assert(out_33   == 3'b000);
+    assert(out_33f  == 3'b000);
+    assert(out_33w  == 3'b000);
+
+    assert(enum_out_33   == {ZERO, ZERO, ZERO});
+    assert(enum_out_33f  == {ZERO, ZERO, ZERO});
+    assert(enum_out_33w  == {ZERO, ZERO, ZERO});
+
+    assert(fail_31f       == 1'b1);
+    assert(enum_fail_31f  == 1'b1);
+    assert(fail_33f       == 1'b1);
+    assert(enum_fail_33f  == 1'b1);
+
+    assert(where_31w      == 3'b100);
+    assert(enum_where_31w == 3'b100);
+    assert(where_33w      == 3'b100);
+    assert(enum_where_33w == 3'b100);
+
+    assert(total_31w      == 1'b0);
+    assert(enum_total_31w == 1'b0);
+    assert(total_33w      == 1'b0);
+    assert(enum_total_33w == 1'b0);
+
+    cycle_start();
+    in = 3'b111;
+    enum_in = {ONE, ONE, ONE};
+
+    cycle_end();
+    assert(out_31         == 1'b1);
+    assert(out_31f        == 1'b1);
+    assert(out_31w        == 1'b1);
+
+    assert(enum_out_31    == ONE);
+    assert(enum_out_31f   == ONE);
+    assert(enum_out_31w   == ONE);
+
+    assert(out_33   == 3'b111);
+    assert(out_33f  == 3'b111);
+    assert(out_33w  == 3'b111);
+
+    assert(enum_out_33   == {ONE, ONE, ONE});
+    assert(enum_out_33f  == {ONE, ONE, ONE});
+    assert(enum_out_33w  == {ONE, ONE, ONE});
+
+    assert(fail_31f       == 1'b0);
+    assert(enum_fail_31f  == 1'b0);
+    assert(fail_33f       == 1'b0);
+    assert(enum_fail_33f  == 1'b0);
+
+    assert(where_31w      == 3'b000);
+    assert(enum_where_31w == 3'b000);
+    assert(where_33w      == 3'b000);
+    assert(enum_where_33w == 3'b000);
+
+    assert(total_31w      == 1'b0);
+    assert(enum_total_31w == 1'b0);
+    assert(total_33w      == 1'b0);
+    assert(enum_total_33w == 1'b0);
+
+    cycle_start();
+    in = 3'b110;
+    enum_in = {ONE, ONE, ZERO};
+
+    cycle_end();
+    assert(out_31         == 1'b1);
+    assert(out_31f        == 1'b1);
+    assert(out_31w        == 1'b1);
+
+    assert(enum_out_31    == ONE);
+    assert(enum_out_31f   == ONE);
+    assert(enum_out_31w   == ONE);
+
+    assert(out_33   == 3'b111);
+    assert(out_33f  == 3'b111);
+    assert(out_33w  == 3'b111);
+
+    assert(enum_out_33   == {ONE, ONE, ONE});
+    assert(enum_out_33f  == {ONE, ONE, ONE});
+    assert(enum_out_33w  == {ONE, ONE, ONE});
+
+    assert(fail_31f       == 1'b1);
+    assert(enum_fail_31f  == 1'b1);
+    assert(fail_33f       == 1'b1);
+    assert(enum_fail_33f  == 1'b1);
+
+    assert(where_31w      == 3'b001);
+    assert(enum_where_31w == 3'b001);
+    assert(where_33w      == 3'b001);
+    assert(enum_where_33w == 3'b001);
+
+    assert(total_31w      == 1'b0);
+    assert(enum_total_31w == 1'b0);
+    assert(total_33w      == 1'b0);
+    assert(enum_total_33w == 1'b0);
+
+    cycle_start();
+    in = 3'b101;
+    enum_in = {ONE, ZERO, ONE};
+
+    cycle_end();
+    assert(out_31         == 1'b1);
+    assert(out_31f        == 1'b1);
+    assert(out_31w        == 1'b1);
+
+    assert(enum_out_31    == ONE);
+    assert(enum_out_31f   == ONE);
+    assert(enum_out_31w   == ONE);
+
+    assert(out_33   == 3'b111);
+    assert(out_33f  == 3'b111);
+    assert(out_33w  == 3'b111);
+
+    assert(enum_out_33   == {ONE, ONE, ONE});
+    assert(enum_out_33f  == {ONE, ONE, ONE});
+    assert(enum_out_33w  == {ONE, ONE, ONE});
+
+    assert(fail_31f       == 1'b1);
+    assert(enum_fail_31f  == 1'b1)
+    assert(fail_33f       == 1'b1);;
+    assert(enum_fail_33f  == 1'b1);
+
+    assert(where_31w      == 3'b010);
+    assert(enum_where_31w == 3'b010);
+    assert(where_33w      == 3'b010);
+    assert(enum_where_33w == 3'b010);
+
+    assert(total_31w      == 1'b0);
+    assert(enum_total_31w == 1'b0);
+    assert(total_33w      == 1'b0);
+    assert(enum_total_33w == 1'b0);
+
+    cycle_start();
+    in = 3'b011;
+    enum_in = {ZERO, ONE, ONE};
+
+    cycle_end();
+    assert(out_31         == 1'b1);
+    assert(out_31f        == 1'b1);
+    assert(out_31w        == 1'b1);
+
+    assert(enum_out_31    == ONE);
+    assert(enum_out_31f   == ONE);
+    assert(enum_out_31w   == ONE);
+
+    assert(out_33   == 3'b111);
+    assert(out_33f  == 3'b111);
+    assert(out_33w  == 3'b111);
+
+    assert(enum_out_33   == {ONE, ONE, ONE});
+    assert(enum_out_33f  == {ONE, ONE, ONE});
+    assert(enum_out_33w  == {ONE, ONE, ONE});
+
+    assert(fail_31f       == 1'b1);
+    assert(enum_fail_31f  == 1'b1);
+    assert(fail_33f       == 1'b1);
+    assert(enum_fail_33f  == 1'b1);
+
+    assert(where_31w      == 3'b100);
+    assert(enum_where_31w == 3'b100);
+    assert(where_33w      == 3'b100);
+    assert(enum_where_33w == 3'b100);
+
+    assert(total_31w      == 1'b0);
+    assert(enum_total_31w == 1'b0);
+    assert(total_33w      == 1'b0);
+    assert(enum_total_33w == 1'b0);
+
+
+  // Check that the total fault works
+  cycle_start();
+  enum_in = {ZERO, ONE, TWO};
+
+  cycle_end();
+  assert(enum_total_31w == 1'b1);
+  assert(enum_total_33w == 1'b1);
+
+  cycle_start();
+  enum_in = {ZERO, TWO, ONE};
+
+  cycle_end();
+  assert(enum_total_31w == 1'b1);
+  assert(enum_total_33w == 1'b1);
+
+  cycle_start();
+  enum_in = {ONE, ZERO, TWO};
+
+  cycle_end();
+  assert(enum_total_31w == 1'b1);
+  assert(enum_total_33w == 1'b1);
+
+  cycle_start();
+  enum_in = {ONE, TWO, ZERO};
+
+  cycle_end();
+  assert(enum_total_31w == 1'b1);
+  assert(enum_total_33w == 1'b1);
+
+  cycle_start();
+  enum_in = {TWO, ZERO, ONE};
+
+  cycle_end();
+  assert(enum_total_31w == 1'b1);
+  assert(enum_total_33w == 1'b1);
+
+
+  cycle_start();
+  enum_in = {TWO, ONE, ZERO};
+
+  cycle_end();
+  assert(enum_total_31w == 1'b1);
+  assert(enum_total_33w == 1'b1);
+
+  end
+endmodule
+

--- a/test/tb_voter_macros.sv
+++ b/test/tb_voter_macros.sv
@@ -45,6 +45,16 @@ module tb_voter_macros;
   logic [2:0] where_33w;
   logic       total_33w;
 
+  // Parameterized Versions
+  logic out_X1_3, out_X1_2, out_X1_1;
+  logic out_X1f_3, out_X1f_2, out_X1f_1;
+  logic fail_X1f_3, fail_X1f_2, fail_X1f_1;
+
+  logic [2:0] out_XX_3, out_XX_2, out_XX_1;
+  logic [2:0] out_XXf_3, out_XXf_2, out_XXf_1; 
+  logic fail_XXf_3, fail_XXf_2, fail_XXf_1;
+
+
   // The same thing but with enums to ensure macros run fine with those
   typedef enum logic [1:0] {ZERO, ONE, TWO}  dummy_enum_t;
 
@@ -60,6 +70,15 @@ module tb_voter_macros;
   logic [2:0]        enum_where_33w;
   logic              enum_total_33w;
 
+  // Parameterized Versions with Enums
+  dummy_enum_t enum_out_X1_3, enum_out_X1_2, enum_out_X1_1;
+  dummy_enum_t enum_out_X1f_3, enum_out_X1f_2, enum_out_X1f_1;
+  logic enum_fail_X1f_3, enum_fail_X1f_2, enum_fail_X1f_1;
+
+  dummy_enum_t [2:0] enum_out_XX_3, enum_out_XX_2, enum_out_XX_1;
+  dummy_enum_t [2:0] enum_out_XXf_3, enum_out_XXf_2, enum_out_XXf_1; 
+  logic enum_fail_XXf_3, enum_fail_XXf_2, enum_fail_XXf_1;
+
   /**********************
    *  DUTs              *
    **********************/
@@ -72,6 +91,23 @@ module tb_voter_macros;
   `VOTE33F(in, out_33f, fail_33f);
   `VOTE33W(in, out_33w, where_33w, total_33w);
 
+  // Parameterized Versions
+  `VOTEX1F(3, in, out_X1f_3, fail_X1f_3);
+  `VOTEX1F(2, in, out_X1f_2, fail_X1f_2);
+  `VOTEX1F(1, in, out_X1f_1, fail_X1f_1);
+
+  `VOTEX1 (3, in, out_X1_3);
+  `VOTEX1 (2, in, out_X1_2);
+  `VOTEX1 (1, in, out_X1_1);
+
+  `VOTEXXF(3, in, out_XXf_3, fail_XXf_3);
+  `VOTEXXF(2, in, out_XXf_2, fail_XXf_2);
+  `VOTEXXF(1, in, out_XXf_1, fail_XXf_1);
+
+  `VOTEXX (3, in, out_XX_3);
+  `VOTEXX (2, in, out_XX_2);
+  `VOTEXX (1, in, out_XX_1);
+
   // The same thing but with enums to ensure macros run fine with those
   `VOTE31 (enum_in, enum_out_31);
   `VOTE31F(enum_in, enum_out_31f, enum_fail_31f);
@@ -81,340 +117,275 @@ module tb_voter_macros;
   `VOTE33F(enum_in, enum_out_33f, enum_fail_33f);
   `VOTE33W(enum_in, enum_out_33w, enum_where_33w, enum_total_33w);
 
+  // Parameterized Versions with Enums
+  `VOTEX1 (3, enum_in, enum_out_X1_3);
+  `VOTEX1 (2, enum_in, enum_out_X1_2);
+  `VOTEX1 (1, enum_in, enum_out_X1_1);
+
+  `VOTEX1F(3, enum_in, enum_out_X1f_3, enum_fail_X1f_3);
+  `VOTEX1F(2, enum_in, enum_out_X1f_2, enum_fail_X1f_2);
+  `VOTEX1F(1, enum_in, enum_out_X1f_1, enum_fail_X1f_1);
+
+  `VOTEXX (3, enum_in, enum_out_XX_3);
+  `VOTEXX (2, enum_in, enum_out_XX_2);
+  `VOTEXX (1, enum_in, enum_out_XX_1);
+
+  `VOTEXXF(3, enum_in, enum_out_XXf_3, enum_fail_XXf_3);
+  `VOTEXXF(2, enum_in, enum_out_XXf_2, enum_fail_XXf_2);
+  `VOTEXXF(1, enum_in, enum_out_XXf_1, enum_fail_XXf_1);
+
+  /**********************
+   *  Tests             *
+   **********************/
+
+  // Proc to group same outputs (Invariants)
+  initial begin
+    for (int cycle = 0; cycle < 8; cycle++) begin
+      cycle_start();
+      cycle_end();
+
+      // 31 / X1 / XX and f / w versions are a subset of 33 versions
+      assert(out_33f              === out_33);
+      assert(out_33w              === out_33);
+      assert(out_XX_3             === out_33);
+      assert(out_XXf_3            === out_33);
+
+      assert(out_31               === out_33[0]);
+      assert(out_31f              === out_33[0]);
+      assert(out_31w              === out_33[0]);
+      assert(out_X1_3             === out_33[0]);
+      assert(out_X1f_3            === out_33[0]);
+      // -> out_33 needs per case testing
+
+      // Out of lower dimension parameterizations are pass-through
+      assert(out_XX_2[1:0]        === in[1:0]);
+      assert(out_XX_1[0:0]        === in[0:0]);
+      assert(out_XXf_2[1:0]       === in[1:0]);
+      assert(out_XXf_1[0:0]       === in[0:0]);
+
+      assert(out_X1_2             === in[0]);
+      assert(out_X1_1             === in[0]);
+      assert(out_X1f_2            === in[0]);
+      assert(out_X1f_1            === in[0]);
+
+      // Out of lower dimension parameterizations do not assign anything outside their range
+      assert(out_XX_2[2:2]        === 1'bX);
+      assert(out_XX_1[2:1]        === 2'bXX);
+      assert(out_XXf_2[2:2]       === 1'bX);
+      assert(out_XXf_1[2:1]       === 2'bXX);
+      
+      // Same for enums
+      // 31 / X1 / XX and f / w versions are a subset of 33 versions
+      assert(enum_out_33f         === enum_out_33);
+      assert(enum_out_33w         === enum_out_33);
+      assert(enum_out_XX_3        === enum_out_33);
+      assert(enum_out_XXf_3       === enum_out_33);
+
+      assert(enum_out_31          === enum_out_33[0]);
+      assert(enum_out_31f         === enum_out_33[0]);
+      assert(enum_out_31w         === enum_out_33[0]);
+      assert(enum_out_X1_3        === enum_out_33[0]);
+      assert(enum_out_X1f_3       === enum_out_33[0]);
+      // -> enum_out_33 needs per case testing
+
+      // Out of lower dimension parameterizations are pass-through
+      assert(enum_out_XX_2[1:0]   === enum_in[1:0]);
+      assert(enum_out_XX_1[0:0]   === enum_in[0:0]);
+      assert(enum_out_XXf_2[1:0]  === enum_in[1:0]);
+      assert(enum_out_XXf_1[0:0]  === enum_in[0:0]);
+
+      assert(enum_out_X1_2        === enum_in[0]);
+      assert(enum_out_X1_1        === enum_in[0]);
+      assert(enum_out_X1f_2       === enum_in[0]);
+      assert(enum_out_X1f_1       === enum_in[0]);
+
+      // Out of lower dimension parameterizations do not assign anything outside their range
+      assert(enum_out_XX_2[2:2]   === 2'bXX);
+      assert(enum_out_XX_1[2:1]   === 4'bXXXX);
+      assert(enum_out_XXf_2[2:2]  === 2'bXX);
+      assert(enum_out_XXf_1[2:1]  === 4'bXXXX);
+
+      // Fail signals with 3 inputs are the same
+      assert(enum_fail_31f        === fail_31f);
+      assert(fail_33f             === fail_31f);
+      assert(enum_fail_33f        === fail_31f);
+      assert(fail_X1f_3           === fail_31f);
+      assert(fail_XXf_3           === fail_31f);
+      assert(enum_fail_X1f_3      === fail_31f);
+      assert(enum_fail_XXf_3      === fail_31f);
+      // -> fail_31f needs per case testing
+
+      // Fail signals with 2 inputs are the same
+      assert(fail_XXf_2           === fail_X1f_2);
+      assert(enum_fail_X1f_2      === fail_X1f_2);
+      assert(enum_fail_XXf_2      === fail_X1f_2);
+      // -> fail_X1f_2 needs per case testing
+
+      // Fail signals with 1 input are constant 0
+      assert(fail_X1f_1           === 1'b0);
+      assert(fail_XXf_1           === 1'b0);
+      assert(enum_fail_X1f_1      === 1'b0);
+      assert(enum_fail_XXf_1      === 1'b0);
+
+      // Where signals are always the same
+      assert(enum_where_31w       === where_31w);
+      assert(where_33w            === where_31w);
+      assert(enum_where_33w       === where_31w);
+      // -> where_31w needs per case testing
+
+      // Total failure can only happen if all 3 things are different
+      // For logic only this is not the case, so input always 0.
+      assert(total_31w            === 1'b0);
+      assert(total_31w            === 1'b0);
+      // For enums however we can assign other values than ZERO and ONE
+      assert(enum_total_33w       === enum_total_31w);
+      // -> enum_total_31w needs per case testing
+
+    end
+  end
+
+  // Proc to do actual testing
   initial begin
     cycle_start();
     in = 3'b000;
     enum_in = {ZERO, ZERO, ZERO};
 
     cycle_end();
-    assert(out_31         == 1'b0);
-    assert(out_31f        == 1'b0);
-    assert(out_31w        == 1'b0);
+    assert(out_33         === 3'b000);
+    assert(enum_out_33    === {ZERO, ZERO, ZERO});
 
-    assert(enum_out_31    == ZERO);
-    assert(enum_out_31f   == ZERO);
-    assert(enum_out_31w   == ZERO);
-
-    assert(out_33   == 3'b000);
-    assert(out_33f  == 3'b000);
-    assert(out_33w  == 3'b000);
-
-    assert(enum_out_33   == {ZERO, ZERO, ZERO});
-    assert(enum_out_33f  == {ZERO, ZERO, ZERO});
-    assert(enum_out_33w  == {ZERO, ZERO, ZERO});
-
-    assert(fail_31f       == 1'b0);
-    assert(enum_fail_31f  == 1'b0);
-    assert(fail_33f       == 1'b0);
-    assert(enum_fail_33f  == 1'b0);
-
-    assert(where_31w      == 3'b000);
-    assert(enum_where_31w == 3'b000);
-    assert(where_33w      == 3'b000);
-    assert(enum_where_33w == 3'b000);
-
-    assert(total_31w      == 1'b0);
-    assert(enum_total_31w == 1'b0);
-    assert(total_33w      == 1'b0);
-    assert(enum_total_33w == 1'b0);
+    assert(fail_31f       === 1'b0);
+    assert(fail_X1f_2     === 1'b0);
+    assert(where_31w      === 3'b000);
+    assert(enum_total_31w === 1'b0);
 
     cycle_start();
     in = 3'b001;
     enum_in = {ZERO, ZERO, ONE};
 
     cycle_end();
-    assert(out_31         == 1'b0);
-    assert(out_31f        == 1'b0);
-    assert(out_31w        == 1'b0);
+    assert(out_33         === 3'b000);
+    assert(enum_out_33    === {ZERO, ZERO, ZERO});
 
-    assert(enum_out_31    == ZERO);
-    assert(enum_out_31f   == ZERO);
-    assert(enum_out_31w   == ZERO);
-
-    assert(out_33   == 3'b000);
-    assert(out_33f  == 3'b000);
-    assert(out_33w  == 3'b000);
-
-    assert(enum_out_33   == {ZERO, ZERO, ZERO});
-    assert(enum_out_33f  == {ZERO, ZERO, ZERO});
-    assert(enum_out_33w  == {ZERO, ZERO, ZERO});
-
-    assert(fail_31f       == 1'b1);
-    assert(enum_fail_31f  == 1'b1);
-    assert(fail_33f       == 1'b1);
-    assert(enum_fail_33f  == 1'b1);
-
-    assert(where_31w      == 3'b001);
-    assert(enum_where_31w == 3'b001);
-    assert(where_33w      == 3'b001);
-    assert(enum_where_33w == 3'b001);
-
-    assert(total_31w      == 1'b0);
-    assert(enum_total_31w == 1'b0);
-    assert(total_33w      == 1'b0);
-    assert(enum_total_33w == 1'b0);
-
+    assert(fail_31f       === 1'b1);
+    assert(fail_X1f_2     === 1'b1);
+    assert(where_31w      === 3'b001);
+    assert(enum_total_31w === 1'b0);
 
     cycle_start();
     in = 3'b010;
     enum_in = {ZERO, ONE, ZERO};
 
     cycle_end();
-    assert(out_31         == 1'b0);
-    assert(out_31f        == 1'b0);
-    assert(out_31w        == 1'b0);
+    assert(out_33         === 3'b000);
+    assert(enum_out_33    === {ZERO, ZERO, ZERO});
 
-    assert(enum_out_31    == ZERO);
-    assert(enum_out_31f   == ZERO);
-    assert(enum_out_31w   == ZERO);
-
-    assert(out_33   == 3'b000);
-    assert(out_33f  == 3'b000);
-    assert(out_33w  == 3'b000);
-
-    assert(enum_out_33   == {ZERO, ZERO, ZERO});
-    assert(enum_out_33f  == {ZERO, ZERO, ZERO});
-    assert(enum_out_33w  == {ZERO, ZERO, ZERO});
-
-    assert(fail_31f       == 1'b1);
-    assert(enum_fail_31f  == 1'b1);
-    assert(fail_33f       == 1'b1);
-    assert(enum_fail_33f  == 1'b1);
-
-    assert(where_31w      == 3'b010);
-    assert(enum_where_31w == 3'b010);
-    assert(where_33w      == 3'b010);
-    assert(enum_where_33w == 3'b010);
-
-    assert(total_31w      == 1'b0);
-    assert(enum_total_31w == 1'b0);
-    assert(total_33w      == 1'b0);
-    assert(enum_total_33w == 1'b0);
+    assert(fail_31f       === 1'b1);
+    assert(fail_X1f_2     === 1'b1);
+    assert(where_31w      === 3'b010);
+    assert(enum_total_31w === 1'b0);
 
     cycle_start();
     in = 3'b100;
     enum_in = {ONE, ZERO, ZERO};
 
     cycle_end();
-    assert(out_31         == 1'b0);
-    assert(out_31f        == 1'b0);
-    assert(out_31w        == 1'b0);
+    assert(out_33         === 3'b000);
+    assert(enum_out_33    === {ZERO, ZERO, ZERO});
 
-    assert(enum_out_31    == ZERO);
-    assert(enum_out_31f   == ZERO);
-    assert(enum_out_31w   == ZERO);
-
-    assert(out_33   == 3'b000);
-    assert(out_33f  == 3'b000);
-    assert(out_33w  == 3'b000);
-
-    assert(enum_out_33   == {ZERO, ZERO, ZERO});
-    assert(enum_out_33f  == {ZERO, ZERO, ZERO});
-    assert(enum_out_33w  == {ZERO, ZERO, ZERO});
-
-    assert(fail_31f       == 1'b1);
-    assert(enum_fail_31f  == 1'b1);
-    assert(fail_33f       == 1'b1);
-    assert(enum_fail_33f  == 1'b1);
-
-    assert(where_31w      == 3'b100);
-    assert(enum_where_31w == 3'b100);
-    assert(where_33w      == 3'b100);
-    assert(enum_where_33w == 3'b100);
-
-    assert(total_31w      == 1'b0);
-    assert(enum_total_31w == 1'b0);
-    assert(total_33w      == 1'b0);
-    assert(enum_total_33w == 1'b0);
+    assert(fail_31f       === 1'b1);
+    assert(fail_X1f_2     === 1'b0);
+    assert(where_31w      === 3'b100);
+    assert(enum_total_31w === 1'b0);
 
     cycle_start();
     in = 3'b111;
     enum_in = {ONE, ONE, ONE};
 
     cycle_end();
-    assert(out_31         == 1'b1);
-    assert(out_31f        == 1'b1);
-    assert(out_31w        == 1'b1);
+    assert(out_33         === 3'b111);
+    assert(enum_out_33    === {ONE, ONE, ONE});
 
-    assert(enum_out_31    == ONE);
-    assert(enum_out_31f   == ONE);
-    assert(enum_out_31w   == ONE);
-
-    assert(out_33   == 3'b111);
-    assert(out_33f  == 3'b111);
-    assert(out_33w  == 3'b111);
-
-    assert(enum_out_33   == {ONE, ONE, ONE});
-    assert(enum_out_33f  == {ONE, ONE, ONE});
-    assert(enum_out_33w  == {ONE, ONE, ONE});
-
-    assert(fail_31f       == 1'b0);
-    assert(enum_fail_31f  == 1'b0);
-    assert(fail_33f       == 1'b0);
-    assert(enum_fail_33f  == 1'b0);
-
-    assert(where_31w      == 3'b000);
-    assert(enum_where_31w == 3'b000);
-    assert(where_33w      == 3'b000);
-    assert(enum_where_33w == 3'b000);
-
-    assert(total_31w      == 1'b0);
-    assert(enum_total_31w == 1'b0);
-    assert(total_33w      == 1'b0);
-    assert(enum_total_33w == 1'b0);
+    assert(fail_31f       === 1'b0);
+    assert(fail_X1f_2     === 1'b0);
+    assert(where_31w      === 3'b000);
+    assert(enum_total_31w === 1'b0);
 
     cycle_start();
     in = 3'b110;
     enum_in = {ONE, ONE, ZERO};
 
     cycle_end();
-    assert(out_31         == 1'b1);
-    assert(out_31f        == 1'b1);
-    assert(out_31w        == 1'b1);
+    assert(out_33         === 3'b111);
+    assert(enum_out_33    === {ONE, ONE, ONE});
 
-    assert(enum_out_31    == ONE);
-    assert(enum_out_31f   == ONE);
-    assert(enum_out_31w   == ONE);
-
-    assert(out_33   == 3'b111);
-    assert(out_33f  == 3'b111);
-    assert(out_33w  == 3'b111);
-
-    assert(enum_out_33   == {ONE, ONE, ONE});
-    assert(enum_out_33f  == {ONE, ONE, ONE});
-    assert(enum_out_33w  == {ONE, ONE, ONE});
-
-    assert(fail_31f       == 1'b1);
-    assert(enum_fail_31f  == 1'b1);
-    assert(fail_33f       == 1'b1);
-    assert(enum_fail_33f  == 1'b1);
-
-    assert(where_31w      == 3'b001);
-    assert(enum_where_31w == 3'b001);
-    assert(where_33w      == 3'b001);
-    assert(enum_where_33w == 3'b001);
-
-    assert(total_31w      == 1'b0);
-    assert(enum_total_31w == 1'b0);
-    assert(total_33w      == 1'b0);
-    assert(enum_total_33w == 1'b0);
+    assert(fail_31f       === 1'b1);
+    assert(fail_X1f_2     === 1'b1);
+    assert(where_31w      === 3'b001);
+    assert(enum_total_31w === 1'b0);
 
     cycle_start();
     in = 3'b101;
     enum_in = {ONE, ZERO, ONE};
 
     cycle_end();
-    assert(out_31         == 1'b1);
-    assert(out_31f        == 1'b1);
-    assert(out_31w        == 1'b1);
+    assert(out_33         === 3'b111);
+    assert(enum_out_33    === {ONE, ONE, ONE});
 
-    assert(enum_out_31    == ONE);
-    assert(enum_out_31f   == ONE);
-    assert(enum_out_31w   == ONE);
-
-    assert(out_33   == 3'b111);
-    assert(out_33f  == 3'b111);
-    assert(out_33w  == 3'b111);
-
-    assert(enum_out_33   == {ONE, ONE, ONE});
-    assert(enum_out_33f  == {ONE, ONE, ONE});
-    assert(enum_out_33w  == {ONE, ONE, ONE});
-
-    assert(fail_31f       == 1'b1);
-    assert(enum_fail_31f  == 1'b1)
-    assert(fail_33f       == 1'b1);;
-    assert(enum_fail_33f  == 1'b1);
-
-    assert(where_31w      == 3'b010);
-    assert(enum_where_31w == 3'b010);
-    assert(where_33w      == 3'b010);
-    assert(enum_where_33w == 3'b010);
-
-    assert(total_31w      == 1'b0);
-    assert(enum_total_31w == 1'b0);
-    assert(total_33w      == 1'b0);
-    assert(enum_total_33w == 1'b0);
+    assert(fail_31f       === 1'b1);
+    assert(fail_X1f_2     === 1'b1);
+    assert(where_31w      === 3'b010);
+    assert(enum_total_31w === 1'b0);
 
     cycle_start();
     in = 3'b011;
     enum_in = {ZERO, ONE, ONE};
 
     cycle_end();
-    assert(out_31         == 1'b1);
-    assert(out_31f        == 1'b1);
-    assert(out_31w        == 1'b1);
+    assert(out_33        === 3'b111);
+    assert(enum_out_33   === {ONE, ONE, ONE});
 
-    assert(enum_out_31    == ONE);
-    assert(enum_out_31f   == ONE);
-    assert(enum_out_31w   == ONE);
-
-    assert(out_33   == 3'b111);
-    assert(out_33f  == 3'b111);
-    assert(out_33w  == 3'b111);
-
-    assert(enum_out_33   == {ONE, ONE, ONE});
-    assert(enum_out_33f  == {ONE, ONE, ONE});
-    assert(enum_out_33w  == {ONE, ONE, ONE});
-
-    assert(fail_31f       == 1'b1);
-    assert(enum_fail_31f  == 1'b1);
-    assert(fail_33f       == 1'b1);
-    assert(enum_fail_33f  == 1'b1);
-
-    assert(where_31w      == 3'b100);
-    assert(enum_where_31w == 3'b100);
-    assert(where_33w      == 3'b100);
-    assert(enum_where_33w == 3'b100);
-
-    assert(total_31w      == 1'b0);
-    assert(enum_total_31w == 1'b0);
-    assert(total_33w      == 1'b0);
-    assert(enum_total_33w == 1'b0);
-
+    assert(fail_31f       === 1'b1);
+    assert(fail_X1f_2     === 1'b0);
+    assert(where_31w      === 3'b100);
+    assert(enum_total_31w === 1'b0);
 
   // Check that the total fault works
   cycle_start();
   enum_in = {ZERO, ONE, TWO};
 
   cycle_end();
-  assert(enum_total_31w == 1'b1);
-  assert(enum_total_33w == 1'b1);
+  assert(enum_total_31w === 1'b1);
 
   cycle_start();
   enum_in = {ZERO, TWO, ONE};
 
   cycle_end();
-  assert(enum_total_31w == 1'b1);
-  assert(enum_total_33w == 1'b1);
+  assert(enum_total_31w === 1'b1);
 
   cycle_start();
   enum_in = {ONE, ZERO, TWO};
 
   cycle_end();
-  assert(enum_total_31w == 1'b1);
-  assert(enum_total_33w == 1'b1);
+  assert(enum_total_31w === 1'b1);
 
   cycle_start();
   enum_in = {ONE, TWO, ZERO};
 
   cycle_end();
-  assert(enum_total_31w == 1'b1);
-  assert(enum_total_33w == 1'b1);
+  assert(enum_total_31w === 1'b1);
 
   cycle_start();
   enum_in = {TWO, ZERO, ONE};
 
   cycle_end();
-  assert(enum_total_31w == 1'b1);
-  assert(enum_total_33w == 1'b1);
-
+  assert(enum_total_31w === 1'b1);
 
   cycle_start();
   enum_in = {TWO, ONE, ZERO};
 
   cycle_end();
-  assert(enum_total_31w == 1'b1);
-  assert(enum_total_33w == 1'b1);
+  assert(enum_total_31w === 1'b1);
 
   end
 endmodule


### PR DESCRIPTION
- Added fault detection only voters
- Added single-line voting macros
   - Macros instantiate voter cells (so they could easily be replaced with technology-specific cells)
   - Macros automatically uniquely name underlying voter cells
   - Macros usable with bender unclude
- Added testbenches for above functionality
- Updated README.md accordingly