### PR TITLE
Fix synthesis problems with Voter Macros in synopsys dc

### DIFF
--- a/include/redundancy_cells/voters.svh
+++ b/include/redundancy_cells/voters.svh
@@ -21,54 +21,70 @@
 // If you want to use different kinds of cells, you only have to change these
 `define TMR_INSTANCE(input_signal, output_signal, instance_name) \
 if ($bits(input_signal[0]) > 1) begin \
-    bitwise_TMR_voter_fail #(.DataWidth($bits(input_signal[0])), .VoterType(2)) instance_name ( \
-      .a_i(`BITWISE(input_signal[0])), \
-      .b_i(`BITWISE(input_signal[1])), \
-      .c_i(`BITWISE(input_signal[2])), \
-      .majority_o(`BITWISE(output_signal)), \
-      .fault_detected_o() \
+    bitwise_TMR_voter_fail #( \
+        .DataWidth($bits(input_signal[0])), \
+        .VoterType(2) \
+    ) instance_name ( \
+        .a_i(`BITWISE(input_signal[0])), \
+        .b_i(`BITWISE(input_signal[1])), \
+        .c_i(`BITWISE(input_signal[2])), \
+        .majority_o(`BITWISE(output_signal)), \
+        .fault_detected_o() \
     ); \
 end else begin \
-    TMR_voter_fail #(.VoterType(2)) instance_name ( \
-      .a_i(input_signal[0]), \
-      .b_i(input_signal[1]), \
-      .c_i(input_signal[2]), \
-      .majority_o(output_signal), \
-      .fault_detected_o() \
+    TMR_voter_fail #( \
+        .VoterType(2) \
+    ) instance_name ( \
+        .a_i(input_signal[0]), \
+        .b_i(input_signal[1]), \
+        .c_i(input_signal[2]), \
+        .majority_o(output_signal), \
+        .fault_detected_o() \
     ); \
 end
 
 `define TMR_INSTANCE_F(input_signal, output_signal, fault_any, instance_name) \
 if ($bits(input_signal[0]) > 1) begin \
-    bitwise_TMR_voter_fail #(.DataWidth($bits(input_signal[0])), .VoterType(1)) instance_name ( \
-      .a_i(`BITWISE(input_signal[0])), \
-      .b_i(`BITWISE(input_signal[1])), \
-      .c_i(`BITWISE(input_signal[2])), \
-      .majority_o(`BITWISE(output_signal)), \
-      .fault_detected_o(fault_any) \
+    bitwise_TMR_voter_fail #( \
+        .DataWidth($bits(input_signal[0])), \
+        .VoterType(1) \
+    ) instance_name ( \
+        .a_i(`BITWISE(input_signal[0])), \
+        .b_i(`BITWISE(input_signal[1])), \
+        .c_i(`BITWISE(input_signal[2])), \
+        .majority_o(`BITWISE(output_signal)), \
+        .fault_detected_o(fault_any) \
     ); \
 end else begin \
-    TMR_voter_fail #(.VoterType(1)) instance_name ( \
-      .a_i(input_signal[0]), \
-      .b_i(input_signal[1]), \
-      .c_i(input_signal[2]), \
-      .majority_o(output_signal), \
-      .fault_detected_o(fault_any) \
+    TMR_voter_fail #( \
+        .VoterType(1) \
+    ) instance_name ( \
+        .a_i(input_signal[0]), \
+        .b_i(input_signal[1]), \
+        .c_i(input_signal[2]), \
+        .majority_o(output_signal), \
+        .fault_detected_o(fault_any) \
     ); \
 end
 
 `define TMR_INSTANCE_W(input_signal, output_signal, fault_210, fault_multiple, instance_name) \
 if ($bits(input_signal[0]) > 1) begin \
-    bitwise_TMR_voter #(.DataWidth($bits(input_signal[0])), .VoterType(2)) instance_name ( \
-      .a_i(`BITWISE(input_signal[0])), \
-      .b_i(`BITWISE(input_signal[1])), \
-      .c_i(`BITWISE(input_signal[2])), \
-      .majority_o(`BITWISE(output_signal)), \
-      .error_o(fault_multiple), \
-      .error_cba_o(fault_210) \
+    bitwise_TMR_voter #( \
+        .DataWidth($bits(input_signal[0])), \
+        .VoterType(2) \
+    ) instance_name ( \
+        .a_i(`BITWISE(input_signal[0])), \
+        .b_i(`BITWISE(input_signal[1])), \
+        .c_i(`BITWISE(input_signal[2])), \
+        .majority_o(`BITWISE(output_signal)), \
+        .error_o(fault_multiple), \
+        .error_cba_o(fault_210) \
     ); \
 end else begin \
-    bitwise_TMR_voter #(.DataWidth($bits(input_signal[0])), .VoterType(2)) instance_name ( \
+    bitwise_TMR_voter #( \
+        .DataWidth($bits(input_signal[0])), \
+        .VoterType(2) \
+    ) instance_name ( \
       .a_i(input_signal[0]), \
       .b_i(input_signal[1]), \
       .c_i(input_signal[2]), \

--- a/include/redundancy_cells/voters.svh
+++ b/include/redundancy_cells/voters.svh
@@ -79,37 +79,32 @@ end else begin \
 end
 
 
-// Macro to create a name based on the current line in the file
-// Name looks like: base_name_L42
-`define UNIQUE_NAME(base_name) ``base_name``_L```__LINE__
-
-
 // 3 -> 1 Voters
 `define VOTE31(input_signal, output_signal) \
-`TMR_INSTANCE(input_signal, output_signal, `UNIQUE_NAME(i_bitwise_TMR_voter_fail));
+`TMR_INSTANCE(input_signal, output_signal, i_bitwise_TMR_voter_fail);
 
 `define VOTE31F(input_signal, output_signal, fault_any) \
-`TMR_INSTANCE_F(input_signal, output_signal, fault_any, `UNIQUE_NAME(i_bitwise_TMR_voter_fail));
+`TMR_INSTANCE_F(input_signal, output_signal, fault_any, i_bitwise_TMR_voter_fail);
 
 `define VOTE31W(input_signal, output_signal, fault_210, fault_multiple) \
-`TMR_INSTANCE_W(input_signal, output_signal, fault_210, fault_multiple, `UNIQUE_NAME(i_bitwise_TMR_voter));
+`TMR_INSTANCE_W(input_signal, output_signal, fault_210, fault_multiple, i_bitwise_TMR_voter);
 
 
 // 3 -> 3 Voters
 `define VOTE33(input_signal, output_signal) \
-`TMR_INSTANCE(input_signal, output_signal[0], `UNIQUE_NAME(i_bitwise_TMR_voter_fail_0)); \
-`TMR_INSTANCE(input_signal, output_signal[1], `UNIQUE_NAME(i_bitwise_TMR_voter_fail_1)); \
-`TMR_INSTANCE(input_signal, output_signal[2], `UNIQUE_NAME(i_bitwise_TMR_voter_fail_2));
+`TMR_INSTANCE(input_signal, output_signal[0], i_bitwise_TMR_voter_fail_0); \
+`TMR_INSTANCE(input_signal, output_signal[1], i_bitwise_TMR_voter_fail_1); \
+`TMR_INSTANCE(input_signal, output_signal[2], i_bitwise_TMR_voter_fail_2);
 
 `define VOTE33F(input_signal, output_signal, fault_any) \
-`TMR_INSTANCE_F(input_signal, output_signal[0], fault_any, `UNIQUE_NAME(i_bitwise_TMR_voter_fail_0f)); \
-`TMR_INSTANCE(input_signal, output_signal[1], `UNIQUE_NAME(i_bitwise_TMR_voter_fail_1)); \
-`TMR_INSTANCE(input_signal, output_signal[2], `UNIQUE_NAME(i_bitwise_TMR_voter_fail_2));
+`TMR_INSTANCE_F(input_signal, output_signal[0], fault_any, i_bitwise_TMR_voter_fail_0f); \
+`TMR_INSTANCE(input_signal, output_signal[1], i_bitwise_TMR_voter_fail_1); \
+`TMR_INSTANCE(input_signal, output_signal[2], i_bitwise_TMR_voter_fail_2);
 
 `define VOTE33W(input_signal, output_signal, fault_210, fault_multiple) \
-`TMR_INSTANCE_W(input_signal, output_signal[0], fault_210, fault_multiple, `UNIQUE_NAME(i_bitwise_TMR_voter_fail_0w)); \
-`TMR_INSTANCE(input_signal, output_signal[1], `UNIQUE_NAME(i_bitwise_TMR_voter_fail_1)); \
-`TMR_INSTANCE(input_signal, output_signal[2], `UNIQUE_NAME(i_bitwise_TMR_voter_fail_2));
+`TMR_INSTANCE_W(input_signal, output_signal[0], fault_210, fault_multiple, i_bitwise_TMR_voter_fail_0w); \
+`TMR_INSTANCE(input_signal, output_signal[1], i_bitwise_TMR_voter_fail_1); \
+`TMR_INSTANCE(input_signal, output_signal[2], i_bitwise_TMR_voter_fail_2);
 
 
 // localparam replicas -> 1 Voters 


### PR DESCRIPTION
In synopsys dc, the \`\_\_LINE\_\_ macro seems to add some character that stops the `UNIQUE_NAME macro
from generating a propper instance name for each voter cell. Instead an error like the following one ocurrs:

```
Error:  /path/to/file.sv:42: Syntax error at or near token '42'
    in macro "__LINE__"
    called from macro "TMR_INSTANCE_F" (line 42)
    called from macro "VOTE33F" (line 42)
    called from macro "VOTEXXF" (line 42)
    called from file "/path/to/file.sv" (line 42). (VER-294)
```

Since all cells instantiated in Voter Macros are inside a generate block the name of the underlying 
instance does not acutallly have to be unique, and we can fix the issue with synopsys dc while not
introducing any issues elsewhere due to names not being unique.